### PR TITLE
Fix lint errors in GA utility

### DIFF
--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -2,8 +2,8 @@
 
 declare global {
   interface Window {
-    dataLayer: any[];
-    gtag: (...args: any[]) => void;
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove `any` usage in Google Analytics typings

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68830556f2b08333ae648a2dfec83592