### PR TITLE
Remove inactive CTA on Brands page

### DIFF
--- a/src/components/BrandShowcase.tsx
+++ b/src/components/BrandShowcase.tsx
@@ -123,18 +123,8 @@ const BrandShowcase = React.memo(() => {
             })}
           </motion.div>
 
-          {/* CTA */}
-          <motion.div 
-            variants={itemVariants}
-            className="text-center mt-16"
-          >
-            <motion.button
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.95 }}
-              className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-8 py-4 rounded-full text-lg font-semibold hover:shadow-lg transition-shadow">
-              View All Case Studies
-            </motion.button>
-          </motion.div>
+          {/* CTA removed: pending case studies */}
+
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the unused "View All Case Studies" button from the Brands page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688aa265a6a0833391495d8b7d0a2ccd