### PR TITLE
fix: prevent header overlap with page content

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,7 +35,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         ogType={routeMetadata.ogType}
       />
       <Header />
-      <main>
+      <main className="pt-24 md:pt-32">
         {children}
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- add top padding to layout main element to avoid header overlap

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd66ffff88333b12542d65422a849