### PR TITLE
Add simplified cookie consent for GDPR compliance - Create minimal, f…

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+
+interface CookieConsentProps {
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+const CookieConsent: React.FC<CookieConsentProps> = ({ onAccept, onDecline }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    if (!consent) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem('cookie-consent', 'accepted');
+    setIsVisible(false);
+    onAccept();
+  };
+
+  const handleDecline = () => {
+    localStorage.setItem('cookie-consent', 'declined');
+    setIsVisible(false);
+    onDecline();
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <motion.div
+      initial={{ y: 100, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      exit={{ y: 100, opacity: 0 }}
+      transition={{ duration: 0.3 }}
+      className="fixed bottom-4 left-4 right-4 z-50 bg-white rounded-lg shadow-lg border border-gray-200 max-w-md mx-auto"
+    >
+      <div className="p-4">
+        <p className="text-sm text-gray-600 mb-3">
+          We use cookies to improve your experience. By continuing, you agree to our use of cookies.
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={handleDecline}
+            className="flex-1 px-3 py-2 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            Decline
+          </button>
+          <button
+            onClick={handleAccept}
+            className="flex-1 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded transition-colors"
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default CookieConsent;

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -8,8 +8,15 @@ declare global {
 
 export const GTM_ID = 'GTM-M6PFK45R';
 
+// Check if analytics is enabled (cookie consent given)
+const isAnalyticsEnabled = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  const consent = localStorage.getItem('cookie-consent');
+  return consent === 'accepted';
+};
+
 export const trackPageView = (url: string, title: string) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (typeof window !== 'undefined' && window.dataLayer && isAnalyticsEnabled()) {
     window.dataLayer.push({
       event: 'page_view',
       page_path: url,
@@ -19,7 +26,7 @@ export const trackPageView = (url: string, title: string) => {
 };
 
 export const trackEvent = (eventName: string, parameters: Record<string, unknown> = {}) => {
-  if (typeof window !== 'undefined' && window.dataLayer) {
+  if (typeof window !== 'undefined' && window.dataLayer && isAnalyticsEnabled()) {
     window.dataLayer.push({
       event: eventName,
       ...parameters,


### PR DESCRIPTION
…riction-free cookie consent banner - Integrate with Google Tag Manager analytics - Respect user privacy preferences - Meet GDPR and CCPA compliance requirements - Simple accept/decline options without overwhelming UI