### PR TITLE
Add legal policy pages for site footer

### DIFF
--- a/src/components/CookiePolicy.tsx
+++ b/src/components/CookiePolicy.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const CookiePolicy: React.FC = () => (
+  <section className="max-w-4xl mx-auto px-4 py-16 text-gray-800">
+    <h1 className="text-3xl font-bold mb-6">Cookie Policy</h1>
+    <p className="mb-4">
+      Dolfyn Brands uses cookies to make our website work effectively and to understand how it is
+      used. Cookies help us deliver a better experience for entrepreneurs exploring our brand
+      acceleration services.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Types of Cookies We Use</h2>
+    <ul className="list-disc list-inside mb-4 space-y-1">
+      <li>Essential cookies that enable core site features.</li>
+      <li>Analytics cookies that help us improve performance and content.</li>
+      <li>Marketing cookies that support our outreach and ad campaigns.</li>
+    </ul>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Managing Cookies</h2>
+    <p>
+      You can adjust your browser settings to refuse cookies or use the cookie banner on our site to
+      accept or decline non-essential cookies. Disabling cookies may affect site functionality.
+    </p>
+  </section>
+);
+
+export default CookiePolicy;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -199,10 +199,10 @@ const Footer: React.FC = () => {
   ];
 
   const legalLinks: LegalLink[] = [
-    { name: 'Privacy Policy', href: '#', description: 'How we protect your data' },
-    { name: 'Terms of Service', href: '#', description: 'Terms and conditions of use' },
-    { name: 'Cookie Policy', href: '#', description: 'How we use cookies' },
-    { name: 'GDPR', href: '#', description: 'Your data protection rights' }
+    { name: 'Privacy Policy', href: '/privacy-policy', description: 'How we protect your data' },
+    { name: 'Terms of Service', href: '/terms-of-service', description: 'Terms and conditions of use' },
+    { name: 'Cookie Policy', href: '/cookie-policy', description: 'How we use cookies' },
+    { name: 'GDPR', href: '/gdpr', description: 'Your data protection rights' }
   ];
 
   // Newsletter subscription handler

--- a/src/components/GDPR.tsx
+++ b/src/components/GDPR.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const GDPR: React.FC = () => (
+  <section className="max-w-4xl mx-auto px-4 py-16 text-gray-800">
+    <h1 className="text-3xl font-bold mb-6">GDPR Commitment</h1>
+    <p className="mb-4">
+      Dolfyn Brands complies with the General Data Protection Regulation (GDPR) and respects the
+      rights of individuals in the European Economic Area. We process personal data to support our
+      brand acceleration services and communicate with entrepreneurs.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Your Rights</h2>
+    <ul className="list-disc list-inside mb-4 space-y-1">
+      <li>Access, update, or delete your personal data.</li>
+      <li>Restrict or object to our processing activities.</li>
+      <li>Receive a copy of your data in a portable format.</li>
+      <li>Withdraw consent for marketing communications at any time.</li>
+    </ul>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Legal Basis</h2>
+    <p className="mb-4">
+      We process data on the basis of legitimate interest in operating our business and with your
+      consent when sending marketing messages. We retain information only as long as necessary for
+      these purposes.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Contact</h2>
+    <p>
+      To exercise your rights or ask questions about our GDPR practices, contact
+      {' '}<a href="mailto:contact@dolfynbrands.com" className="text-blue-600 underline">contact@dolfynbrands.com</a>.
+    </p>
+  </section>
+);
+
+export default GDPR;

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const PrivacyPolicy: React.FC = () => (
+  <section className="max-w-4xl mx-auto px-4 py-16 text-gray-800">
+    <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+    <p className="mb-4">
+      Dolfyn Brands is a full-stack accelerator helping consumer brands scale globally through
+      AI-powered strategy and creative execution. We respect your privacy and are committed to
+      protecting personal information that you share with us.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Information We Collect</h2>
+    <p className="mb-4">
+      We may collect contact details, communications, and usage data when you interact with our
+      website or request information about our services. This helps us respond to inquiries and
+      improve our offerings.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">How We Use Information</h2>
+    <p className="mb-4">
+      Information is used to deliver and enhance our brand acceleration services, provide marketing
+      insights, and maintain the security of our platform. We may also send updates or resources
+      related to growing your brand.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Data Sharing</h2>
+    <p className="mb-4">
+      We do not sell personal data. We may share information with trusted service providers who
+      support our analytics, hosting, or communication tools, and only as necessary to operate our
+      business or comply with legal obligations.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Contact Us</h2>
+    <p>
+      For questions about this policy or your data, please contact us at
+      {' '}<a href="mailto:contact@dolfynbrands.com" className="text-blue-600 underline">contact@dolfynbrands.com</a>.
+    </p>
+  </section>
+);
+
+export default PrivacyPolicy;

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const TermsOfService: React.FC = () => (
+  <section className="max-w-4xl mx-auto px-4 py-16 text-gray-800">
+    <h1 className="text-3xl font-bold mb-6">Terms of Service</h1>
+    <p className="mb-4">
+      These terms govern your use of the Dolfyn Brands website. By accessing or using our site,
+      you agree to comply with these terms and all applicable laws.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Use of Site</h2>
+    <p className="mb-4">
+      You may use this site to learn about our brand acceleration services and to contact our team.
+      You agree not to misuse the site or interfere with its operation.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Intellectual Property</h2>
+    <p className="mb-4">
+      All content, trademarks, and logos on this site are the property of Dolfyn Brands unless
+      otherwise noted. You may not reproduce or distribute this material without permission.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Disclaimer</h2>
+    <p className="mb-4">
+      The information on this site is provided for general informational purposes and is offered
+      &quot;as is&quot; without warranties. We are not liable for any damages arising from its use.
+    </p>
+    <h2 className="text-xl font-semibold mt-6 mb-2">Updates</h2>
+    <p>
+      We may revise these terms from time to time. Continued use of the site after changes
+      constitutes acceptance of the updated terms.
+    </p>
+  </section>
+);
+
+export default TermsOfService;

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -12,6 +12,10 @@ const FAQ = lazy(() => import('../components/FAQ'));
 const VivaEarthLanding = lazy(() => import('../components/VivaEarthLanding'));
 const VivaBloomLanding = lazy(() => import('../components/VivaBloomLanding'));
 const Careers = lazy(() => import('../components/Careers'));
+const PrivacyPolicy = lazy(() => import('../components/PrivacyPolicy'));
+const TermsOfService = lazy(() => import('../components/TermsOfService'));
+const CookiePolicy = lazy(() => import('../components/CookiePolicy'));
+const GDPR = lazy(() => import('../components/GDPR'));
 
 // Home page components
 import Hero from '../components/Hero';
@@ -148,6 +152,42 @@ export const routes: AppRoute[] = [
       description: 'Join the Dolfyn Brands team and be part of our mission to transform brands through innovation and creativity. Apply for exciting career opportunities.',
       keywords: 'careers, jobs, dolfyn brands careers, job opportunities, brand transformation careers',
       ogImage: 'https://dolfynbrands.com/og-careers.jpg',
+      ogType: 'website'
+    }
+  },
+  {
+    path: '/privacy-policy',
+    component: PrivacyPolicy,
+    meta: {
+      title: 'Privacy Policy - Dolfyn Brands',
+      description: 'How Dolfyn Brands collects, uses, and protects personal information.',
+      ogType: 'website'
+    }
+  },
+  {
+    path: '/terms-of-service',
+    component: TermsOfService,
+    meta: {
+      title: 'Terms of Service - Dolfyn Brands',
+      description: 'Terms and conditions for using the Dolfyn Brands website.',
+      ogType: 'website'
+    }
+  },
+  {
+    path: '/cookie-policy',
+    component: CookiePolicy,
+    meta: {
+      title: 'Cookie Policy - Dolfyn Brands',
+      description: 'Details about the cookies used by Dolfyn Brands.',
+      ogType: 'website'
+    }
+  },
+  {
+    path: '/gdpr',
+    component: GDPR,
+    meta: {
+      title: 'GDPR Commitment - Dolfyn Brands',
+      description: 'Your data protection rights under GDPR when interacting with Dolfyn Brands.',
       ogType: 'website'
     }
   },


### PR DESCRIPTION
## Summary
- add dedicated Privacy Policy, Terms of Service, Cookie Policy, and GDPR pages
- wire new pages into router and footer links
- document data practices for Dolfyn Brands brand accelerator

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aff54215f8833395de92359e6254c3