### PR TITLE
feat: persist cookie consent for 90 days

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -11,19 +11,35 @@ const CookieConsent: React.FC<CookieConsentProps> = ({ onAccept, onDecline }) =>
 
   useEffect(() => {
     const consent = localStorage.getItem('cookie-consent');
-    if (!consent) {
-      setIsVisible(true);
+    if (consent) {
+      try {
+        const { timestamp } = JSON.parse(consent);
+        const ninetyDays = 90 * 24 * 60 * 60 * 1000;
+        if (Date.now() - timestamp < ninetyDays) {
+          return;
+        }
+      } catch {
+        // If parsing fails, treat as no consent
+      }
     }
+    setIsVisible(true);
+    localStorage.removeItem('cookie-consent');
   }, []);
 
   const handleAccept = () => {
-    localStorage.setItem('cookie-consent', 'accepted');
+    localStorage.setItem(
+      'cookie-consent',
+      JSON.stringify({ status: 'accepted', timestamp: Date.now() })
+    );
     setIsVisible(false);
     onAccept();
   };
 
   const handleDecline = () => {
-    localStorage.setItem('cookie-consent', 'declined');
+    localStorage.setItem(
+      'cookie-consent',
+      JSON.stringify({ status: 'declined', timestamp: Date.now() })
+    );
     setIsVisible(false);
     onDecline();
   };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import SEO from './SEO';
 import CookieConsent from './CookieConsent';
 import { useRouteMetadata } from '../hooks/useRouteMetadata';
 import { preloadLikelyRoutes } from '../utils/routePreloader';
-import { trackPageView, initializeGTM } from '../utils/ga';
+import { trackPageView, initializeGTM, isAnalyticsEnabled } from '../utils/ga';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -20,6 +20,13 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   // Initialize GTM
   useEffect(() => {
     initializeGTM();
+  }, []);
+
+  // Enable analytics if previously accepted
+  useEffect(() => {
+    if (isAnalyticsEnabled()) {
+      setAnalyticsEnabled(true);
+    }
   }, []);
 
   // Preload likely next routes for better performance

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -8,11 +8,18 @@ declare global {
 
 export const GTM_ID = 'GTM-M6PFK45R';
 
-// Check if analytics is enabled (cookie consent given)
-const isAnalyticsEnabled = (): boolean => {
+// Check if analytics is enabled (cookie consent given and not expired)
+export const isAnalyticsEnabled = (): boolean => {
   if (typeof window === 'undefined') return false;
   const consent = localStorage.getItem('cookie-consent');
-  return consent === 'accepted';
+  if (!consent) return false;
+  try {
+    const { status, timestamp } = JSON.parse(consent);
+    const ninetyDays = 90 * 24 * 60 * 60 * 1000;
+    return status === 'accepted' && Date.now() - timestamp < ninetyDays;
+  } catch {
+    return false;
+  }
 };
 
 export const trackPageView = (url: string, title: string) => {


### PR DESCRIPTION
## Summary
- store cookie consent decisions with timestamps and only prompt again after 90 days
- parse stored consent in analytics utilities and honor 90-day expiry
- enable analytics automatically when prior consent is still valid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff8a1bc988333a7292929f035cc11